### PR TITLE
Enable parent child declarations via ApplicationController

### DIFF
--- a/docs/scripts/application_controller.js
+++ b/docs/scripts/application_controller.js
@@ -1,0 +1,60 @@
+/* global Stimulus */
+
+function camelize(value) {
+  return value.replace(/(?:[_-])([a-z0-9])/g, (_, char) => char.toUpperCase())
+}
+
+function childConnectHandler(event) {
+  if (event.detail.parent === this.identifier) {
+    const controller = event.detail.controller
+    const propertyName = `${camelize(controller.identifier)}Children`
+    this[propertyName].push(controller)
+    controller.parent = this
+  }
+}
+
+// controllers specify children with a static method named children that returns an array of names (in kebab case)
+function specifiesChildren(controller) {
+  return controller.constructor.children !== undefined
+}
+
+// controllers specify a parent with a static method named parent that returns the parent name (in kebab case)
+function specifiesParent(controller) {
+  return controller.constructor.parent !== undefined
+}
+
+export class ApplicationController extends Stimulus.Controller {
+  connect() {
+    // if the controller specifies children, add array for children and listener for child connect event
+    if (specifiesChildren(this)) {
+      console.log(this.identifier + ' specifies children')
+      this.constructor.children.forEach((name) => this.setupChildren(name))
+      this.element.addEventListener('connect', childConnectHandler.bind(this))
+    }
+
+    // if the controller specifies a parent, then dispatch a connect event
+    if (specifiesParent(this)) {
+      console.log(this.identifier + ' specifies a parent')
+      const info = { controller: this, parent: this.constructor.parent }
+      this.element.dispatchEvent(
+        new CustomEvent('connect', { bubbles: true, detail: info })
+      )
+    }
+  }
+
+  disconnect() {
+    if (specifiesChildren(this)) {
+      this.element.removeEventListener('connect', childConnectHandler)
+    }
+
+    if (specifiesParent(this)) {
+      this.parent = null
+    }
+  }
+
+  setupChildren(name) {
+    const propertyName = `${name}Children`
+    this[propertyName] = []
+    this[`${name}Child`] = () => this[propertyName][0]
+  }
+}


### PR DESCRIPTION
Declare parent and child controllers in the same manner as targets, values, and classes. For example, to connect the Math controller to the Equation controller as parent child, the Math controller would contain the children declaration:

```javascript
  static get children() {
    return ['equation']
  }
```

The Equation controller would contain the parent declaration:

```javascript
  static get parent() {
    return 'math'
  }
```

This eliminates the need to make each child controller a target for the parent then load them manually with `this.application.getControllerForElementAndIdentifier`.